### PR TITLE
fix: `maybe` (for naming) as an atom, not a language construct

### DIFF
--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -45,11 +45,11 @@
 
 -export_type([datatype/0, update/1, context/0]).
 
--type maybe(T) :: T | undefined.
+-type 'maybe'(T) :: T | undefined.
 -type datatype() :: term().
 -type typename() :: atom().
--type context() :: maybe(binary()).
--type update(T) :: maybe({typename(), T, context()}).
+-type context() :: 'maybe'(binary()).
+-type update(T) :: 'maybe'({typename(), T, context()}).
 
 %% Constructs a new, empty container for the type. Use this when
 %% creating a new key.
@@ -95,7 +95,7 @@ module_for_type(map)      -> riakc_map.
 
 %% @doc Returns the appropriate container module for the given term,
 %% if possible.
--spec module_for_term(datatype()) -> maybe(module()).
+-spec module_for_term(datatype()) -> 'maybe'(module()).
 module_for_term(T) ->
     lists:foldl(fun(Mod, undefined) ->
                         case Mod:is_type(T) of

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2378,11 +2378,7 @@ remove_queued_request(Ref, State) ->
     end.
 
 %% @private
--ifdef(deprecated_19).
 mk_reqid() -> erlang:phash2(crypto:strong_rand_bytes(10)). % only has to be unique per-pid
--else.
-mk_reqid() -> erlang:phash2(crypto:rand_bytes(10)). % only has to be unique per-pid
--endif.
 
 %% @private
 wait_for_mapred(ReqId, Timeout) ->

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2238,8 +2238,8 @@ start_tls(State=#state{sock=Sock}) ->
     end.
 
 start_auth(State=#state{credentials={User,Pass}, sock=Sock}) ->
-    ok = ssl:send(Sock, riak_pb_codec:encode(#rpbauthreq{user=User,
-                                                         password=Pass})),
+    ok = ssl:send(Sock, riak_pb_codec:encode(#rpbauthreq{user=list_to_binary(User),
+                                                         password=list_to_binary(Pass)})),
     receive
         {ssl_error, Sock, Reason} ->
             {error, Reason};


### PR DESCRIPTION
⚠️ This requires Dialyzer analysis.