### PR TITLE
chore: add format_status/2 callback to riak_pb_socket to hide credentials on crash

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -77,7 +77,7 @@
          replace_coverage/3, replace_coverage/4]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3, format_status/2]).
+         terminate/2, code_change/3, format_status/1, format_status/2]).
 
 %% Yokozuna admin commands
 -export([list_search_indexes/1, list_search_indexes/2,
@@ -1456,11 +1456,16 @@ terminate(_Reason, _State) -> ok.
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %% @private
-format_status(terminate, [_, #state{credentials = {User, _Pass}} = State]) ->
-    State#state{credentials = {User, <<"REDACTED">>}};
+format_status(#{state := #state{credentials = {User, _Pass}} = State} = Status) ->
+    PrunedState = State#state{credentials = {User, "REDACTED"}},
+    maps:put(state, PrunedState, Status);
+format_status(Status) ->
+    Status.
+
+format_status(_, [_, #state{credentials = {User, _Pass}} = State]) ->
+    State#state{credentials = {User, "REDACTED"}};
 format_status(_Opt, [_PDict,State]) ->
     State.
-
 %% ====================================================================
 %% internal functions
 %% ====================================================================

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -77,7 +77,7 @@
          replace_coverage/3, replace_coverage/4]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+         terminate/2, code_change/3, format_status/2]).
 
 %% Yokozuna admin commands
 -export([list_search_indexes/1, list_search_indexes/2,
@@ -1454,6 +1454,12 @@ terminate(_Reason, _State) -> ok.
 
 %% @private
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
+
+%% @private
+format_status(terminate, [_, #state{credentials = {User, _Pass}} = State]) ->
+    State#state{credentials = {User, <<"REDACTED">>}};
+format_status(_Opt, [_PDict,State]) ->
+    State.
 
 %% ====================================================================
 %% internal functions


### PR DESCRIPTION
## Description

When there is crash, the whole state of `riak_pb_socket` `gen_server` gets dumped. This PR adds `format_status/2` callback which, according to the [docs](https://www.erlang.org/docs/24/man/gen_server#Module:format_status-2):

> This function is called by a gen_server process in the following situations:
> - One of [sys:get_status/1,2](https://www.erlang.org/docs/24/man/sys#get_status-1) is invoked to get the gen_server status. Opt is set to the atom normal.
> - The gen_server process terminates abnormally and logs an error. Opt is set to the atom terminate.